### PR TITLE
Added sockets for the leaderboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "jest": "^29.7.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.11.0",
+        "socket.io": "^4.8.1",
         "supertest": "^7.0.0"
       }
     },
@@ -950,6 +951,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -989,6 +996,21 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1346,6 +1368,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/bcrypt": {
       "version": "5.1.1",
@@ -1738,6 +1769,19 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -1937,6 +1981,68 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
+      "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4549,6 +4655,116 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5056,6 +5272,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.11.0",
+    "socket.io": "^4.8.1",
     "supertest": "^7.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 var express = require("express")
 var app = express()
+let http = require('http').createServer(app);
+let io = require('socket.io')(http);
 app.get('/', (req, res) => {
     res.redirect('/mainMenu.html');
 });
@@ -18,7 +20,18 @@ app.use('/api/word', wordsApiRoutes);
 app.use('/api/user', usersApiRoutes);
 app.use('/api/game', gameDataApiRoutes);
 
-module.exports = app.listen(port, () => {
+const wordLengthSocket = require('./sockets/wordLength');
+const totalScoreSocket = require('./sockets/totalScore');
+const highScoreSocket = require('./sockets/highScore');
+const winsSocket = require('./sockets/wins');
+const categoriesSocket = require('./sockets/categories');
+wordLengthSocket(io.of('/word_length'));
+totalScoreSocket(io.of('/total_score'));
+highScoreSocket(io.of('/high_score'));
+winsSocket(io.of('/wins'));
+categoriesSocket(io.of('/categories'));
+
+module.exports = http.listen(port, () => {
     console.log(`App is listening on port ${port}`);
 }).on('error',(err) => {
     console.error("Failed to start server:", err);

--- a/sockets/categories.js
+++ b/sockets/categories.js
@@ -1,0 +1,52 @@
+const client = require('../models/connection');
+
+module.exports = function(io) {
+    io.on('connection', (socket) => {
+        console.log('User connected');
+        socket.on('disconnect', () => {
+            console.log('User disconnected');
+        });
+
+        async function getLongestWordForEachCategory() {
+            let categories = await client.db("words").listCollections().toArray();
+            let collection = client.db('authentication').collection("users");
+            let result = [];
+
+            for(const category of categories){
+                const highest = await collection.aggregate([
+                    { 
+                        $match: { [`answers.${category.name}`]: { $exists: true } } 
+                    },
+                    {
+                        $project: {
+                            username: 1,
+                            word: { $ifNull: [`$answers.${category.name}.word`, ''] },
+                            length: { $strLenCP: { $ifNull: [`$answers.${category.name}.word`, ''] } },
+                        }
+                    },
+                    { 
+                        $sort: { length: -1 } 
+                    },
+                    { 
+                        $limit: 1 
+                    }
+                ]).toArray();
+
+                result.push({
+                    category: category.name,
+                    username: highest[0].username,
+                    word: highest[0].word
+                })
+            }
+            return result;
+        }
+
+
+        setInterval(async () => {
+            let categories = await getLongestWordForEachCategory()
+            let filtered = categories.map(cat => ({ category: cat.category, username: cat.username, word: cat.word }));
+            socket.emit('Categories', filtered);
+            //console.log('Emitting:', filtered);
+        }, 1000);
+    });
+};

--- a/sockets/highScore.js
+++ b/sockets/highScore.js
@@ -1,0 +1,29 @@
+const client = require('../models/connection');
+
+module.exports = function(io) {
+    io.on('connection', (socket) => {
+        console.log('User connected');
+        socket.on('disconnect', () => {
+            console.log('User disconnected');
+        });
+
+        async function getUserByHighScore() {
+            let collection = client.db('authentication').collection("users");
+            const rankedUsers = await collection.aggregate([
+                {
+                    $sort: { high_score: -1 }
+                }
+                ]).toArray();
+
+            return rankedUsers;
+        }
+
+
+        setInterval(async () => {
+            let users = await getUserByHighScore()
+            let filtered = users.map(user => ({ username: user.username, high_score: user.high_score ? user.high_score : 0 }));
+            socket.emit('Users_by_high_score', filtered);
+            //console.log('Emitting:', filtered);
+        }, 1000);
+    });
+};

--- a/sockets/totalScore.js
+++ b/sockets/totalScore.js
@@ -1,0 +1,29 @@
+const client = require('../models/connection');
+
+module.exports = function(io) {
+    io.on('connection', (socket) => {
+        console.log('User connected');
+        socket.on('disconnect', () => {
+            console.log('User disconnected');
+        });
+
+        async function getUserByTotalScore() {
+            let collection = client.db('authentication').collection("users");
+            const rankedUsers = await collection.aggregate([
+                {
+                    $sort: { total_score: -1 }
+                }
+                ]).toArray();
+
+            return rankedUsers;
+        }
+
+
+        setInterval(async () => {
+            let users = await getUserByTotalScore()
+            let filtered = users.map(user => ({ username: user.username, total_score: user.total_score ? user.total_score : 0 }));
+            socket.emit('Users_by_total_score', filtered);
+            //console.log('Emitting:', filtered);
+        }, 1000);
+    });
+};

--- a/sockets/wins.js
+++ b/sockets/wins.js
@@ -1,0 +1,29 @@
+const client = require('../models/connection');
+
+module.exports = function(io) {
+    io.on('connection', (socket) => {
+        console.log('User connected');
+        socket.on('disconnect', () => {
+            console.log('User disconnected');
+        });
+
+        async function getUserByWins() {
+            let collection = client.db('authentication').collection("users");
+            const rankedUsers = await collection.aggregate([
+                {
+                    $sort: { wins: -1 }
+                }
+                ]).toArray();
+
+            return rankedUsers;
+        }
+
+
+        setInterval(async () => {
+            let users = await getUserByWins()
+            let filtered = users.map(user => ({ username: user.username, wins: user.wins ? user.wins : 0 }));
+            socket.emit('Users_by_wins', filtered);
+            //console.log('Emitting:', filtered);
+        }, 1000);
+    });
+};

--- a/sockets/wordLength.js
+++ b/sockets/wordLength.js
@@ -1,0 +1,36 @@
+const client = require('../models/connection');
+
+module.exports = function(io) {
+    io.on('connection', (socket) => {
+        console.log('User connected');
+        socket.on('disconnect', () => {
+            console.log('User disconnected');
+        });
+
+        async function getUserByWordLength() {
+            let collection = client.db('authentication').collection("users");
+            const rankedUsers = await collection.aggregate([
+                {
+                    $project: {
+                        username: 1,
+                        longest_word: 1,
+                        length: { $strLenCP: { $ifNull: ["$longest_word", ""] } }
+                    }
+                },
+                {
+                    $sort: { length: -1 }
+                }
+                ]).toArray();
+
+            return rankedUsers;
+        }
+
+
+        setInterval(async () => {
+            let users = await getUserByWordLength()
+            let filtered = users.map(user => ({ username: user.username, longest_word: user.longest_word ? user.longest_word : '' }));
+            socket.emit('Users_by_word_length', filtered);
+            //console.log('Emitting:', filtered);
+        }, 1000);
+    });
+};


### PR DESCRIPTION
I added 5 sockets to provide real time data for the leaderboard
1. `/word_length` provides users ranked by their longest word
2. `/total_score` users ranked by their total score
3. `/high_score` users ranked by their high score
4. `/wins` users ranked by their number of wins
5. `/categories` a list of categories with the longest word in each and the user that gave it

These sockets each have their own name and can be connected to seperatly in the frontend. To test one out uncomment the console.log line in that socket's file and add the following code into the leaderboard.html file:
`    <script src="/socket.io/socket.io.js"></script>
    <script>
      let socket = io('<socket-name>');
    </script>` and replace `<socket-name>` with the socket you are trying out. Once you go onto the leaderboard page you should see a constant stream of messages in the terminal showing the data received.