### PR TITLE
Added category divisions to the endpoint to get categories

### DIFF
--- a/controllers/GameController.js
+++ b/controllers/GameController.js
@@ -41,12 +41,15 @@
                 console.log('Categories data:', categoriesData);
                 const playersUrl = '/api/game/players/3';
                 const playersResponse = await fetch(playersUrl, {
-                    method: 'GET',
+                    method: 'POST',
                     headers: {
                         'Accept': 'application/json',
                         'Content-Type': 'application/json',
                         'Authorization': localStorage.getItem('accessToken')
-                    }
+                    },
+                    body: JSON.stringify({
+                        categories: categoriesData.data
+                    })
                 });
 
                 if (!playersResponse.ok) {
@@ -448,6 +451,8 @@
                         score: playerScore
                     }),
                 });
+
+                console.log(response);
         
                 if (!response.ok) {
                     throw new Error(`Failed to update game stats: ${response.status}`);

--- a/controllers/gameDataController.js
+++ b/controllers/gameDataController.js
@@ -1,11 +1,14 @@
 const gameData = require('../models/gameData');
 
 const getRandomCategories = async (req, res) => {
+    let game = req.params.game;
+    if(!["History", "Entertainment", "Geography", "Science", "Animals"].includes(game)) game = null;
+
     try {
         console.log('getRandomCategories called with params:', req.params);
         const number = parseInt(req.params.number);
-
-        gameData.getRandomCategories(number, (error, result) => {
+        
+        gameData.getRandomCategories(number, game, (error, result) => {
             if (error) {
                 console.error('Categories error:', error);
                 return res.status(500).json({ message: error.message });
@@ -27,28 +30,19 @@ const getRandomUsers = async (req, res) => {
         let username = req.user?.username;
         console.log('getRandomUsers called with params:', req.params);
         const number = parseInt(req.params.number);
+        const {categories} = req.body;
 
-        // First get random categories
-        gameData.getRandomCategories(5, (categoryError, categories) => {
-            if (categoryError) {
-                console.error('Category error:', categoryError);
-                return res.status(500).json({ message: categoryError.message });
+        // Then get random users for those categories
+        gameData.getRandomUsers(categories, number, username, (userError, rounds) => {
+            if (userError) {
+                console.error('User error:', userError);
+                return res.status(500).json({ message: userError.message });
             }
 
-            console.log('Got categories for users:', categories);
-
-            // Then get random users for those categories
-            gameData.getRandomUsers(categories, number, username, (userError, rounds) => {
-                if (userError) {
-                    console.error('User error:', userError);
-                    return res.status(500).json({ message: userError.message });
-                }
-
-                console.log('Successfully got rounds:', rounds.length);
-                res.status(200).json({
-                    data: rounds,
-                    message: 'Players successfully retrieved'
-                });
+            console.log('Successfully got rounds:', rounds.length);
+            res.status(200).json({
+                data: rounds,
+                message: 'Players successfully retrieved'
             });
         });
     } catch (error) {

--- a/models/gameData.js
+++ b/models/gameData.js
@@ -1,19 +1,32 @@
 const client = require('./connection');
 const db = client.db('words');
 const collection = client.db('authentication').collection("users");
+const games = client.db('games').collection("categories");
 
 // Get random categories from the words database
-async function getRandomCategories(number, callback) {
+async function getRandomCategories(number, game, callback) {
     try {
         console.log('Getting random categories, number:', number);
-        const categories = await db.listCollections().toArray();
-        const names = categories.map(category => category.name);
-        const randomCategories = names
+        if(game){
+            const categories = await games.findOne({ game: game });
+            const names = categories.categories;
+            console.log(categories);
+            const randomCategories = names
             .sort(() => Math.random() - 0.5)
             .slice(0, number);
         
-        console.log('Selected categories:', randomCategories);
-        callback(null, randomCategories);
+            console.log('Selected categories:', randomCategories);
+            callback(null, randomCategories);
+        }else{
+            const categories = await db.listCollections().toArray();
+            const names = categories.map(category => category.name);
+            const randomCategories = names
+                .sort(() => Math.random() - 0.5)
+                .slice(0, number);
+            
+            console.log('Selected categories:', randomCategories);
+            callback(null, randomCategories);
+        }
     } catch (error) {
         console.error('Error getting categories:', error);
         callback({ message: "Error getting categories list" }, null);

--- a/routers/gameDataRouter.js
+++ b/routers/gameDataRouter.js
@@ -3,11 +3,15 @@ let express = require('express');
 let routes = express.Router();
 let authenticator = require('../authenticator');
 
+routes.get('/categories/:number/:game', (req, res) => {
+    controller.getRandomCategories(req, res);
+});
+
 routes.get('/categories/:number', (req, res) => {
     controller.getRandomCategories(req, res);
 });
 
-routes.get('/players/:number', authenticator.check, (req, res) => {
+routes.post('/players/:number', authenticator.check, (req, res) => {
     controller.getRandomUsers(req, res);
 });
 


### PR DESCRIPTION
I added to the endpoint to get random categories so that you can add a path parameter to get only the categories in a particular game. The regular `GET /api/game/categories/:number` still works as it did before but you can now add `/:game` to it (with `game` being one of "History", "Geography", "Animals", "Entertainment" and "Science") and you will only get categories of that type.